### PR TITLE
Update software-development-maintenance-plan.md

### DIFF
--- a/templates/techdoc/62304/software-development-maintenance-plan.md
+++ b/templates/techdoc/62304/software-development-maintenance-plan.md
@@ -144,7 +144,7 @@ e.g., 1.0.0.*
 
 > Describe your policy on what should be documented while you develop software. Maybe you want to require
 > your developers to document all methods which are private. Maybe you want to keep an up-to-date software
-> architecture diagram in the repository, etc. Make sure to mention how trancebility between Software Requirements and Tests is maintained.
+> architecture diagram in the repository, etc. Make sure to mention how traceability between Software Requirements and Tests is maintained.
 
 ## 7 Implementation Verification Activities
 

--- a/templates/techdoc/62304/software-development-maintenance-plan.md
+++ b/templates/techdoc/62304/software-development-maintenance-plan.md
@@ -50,10 +50,11 @@ Please see the relevant processes for the following activities:
 
 ### 2.1 Team
 
-| Role               | Count | Names                    |
-|--------------------|-------|--------------------------|
-| Frontend Developer | 2     | Ada Lovelace, Steve Jobs |
-| Backend Developer  | 1     | Alan Turing              |
+| Role               | Count | Responsibilities                           |
+|--------------------|-------|--------------------------------------------|
+| Head of Development| 1     | Prioritizing tasks and technical oversight |
+| Frontend Developer | 2     | Implementing Frontend Software Requirements|
+| Backend Developer  | 1     | Implementing Backend Software Requirements |
 
 ### 2.2 Software
 
@@ -97,13 +98,13 @@ Describe your device's software safety class according to IEC 62304 and your rea
 
 > The 13485 requires you to specify "Design Phases". Here are some suggestions which you could use.
 
-| Title          | Date | Description |
-|----------------|------|-------------|
-| Specification  |      |             |
-| Implementation |      |             |
-| Testing        |      |             |
-| Validation     |      |             |
-| Release        |      |             |
+| Title          | Estimated Completion Date | Description | Review method                   |
+|----------------|---------------------------|-------------| ------------------------------- |
+| Specification  |                           |             | Software Requirements Checklist |
+| Implementation |                           |             | Code Reviews                    |
+| Testing        |                           |             | System Test                     |
+| Validation     |                           |             | Usability Evaluation            |
+| Release        |                           |             | Release Checklist               |
 
 ## 4 Avoiding Common Software Defects Based on Selected Programming Technology
 
@@ -143,7 +144,7 @@ e.g., 1.0.0.*
 
 > Describe your policy on what should be documented while you develop software. Maybe you want to require
 > your developers to document all methods which are private. Maybe you want to keep an up-to-date software
-> architecture diagram in the repository, etc.
+> architecture diagram in the repository, etc. Make sure to mention how trancebility between Software Requirements and Tests is maintained.
 
 ## 7 Implementation Verification Activities
 


### PR DESCRIPTION
I changed 3 things:
1. "Resources" doesn't contain the names of the developers anymore. Instead, there will just be the needed head count. I've added a column for a description of the "responsibilities" though because that's required by 13485.
2. The "Design Stages" now have a column "Review method" that I've pre-filled with Code Reviews, Checklists etc. This is also required by 13485
3. I've added a sentence to the "Documentation activities". Users should mention how they assure traceability between requirements and tests etc.